### PR TITLE
add note about jdk as prerequisite for make

### DIFF
--- a/README
+++ b/README
@@ -23,8 +23,10 @@ some other compilers:
   but designators such as +03 or -07 are discarded, to be re-generated as
   needed.
 
-Simply type "make" at a command line prompt while in the top directory to build
-the ctzgenerator.jar JAR file.
+Make sure you have got a JDK (Java Development Kit) installed. If not you can
+install that with `sudo apt install default-jdk`.
+Then simply type "make" at a command line prompt while in the top directory to
+build the ctzgenerator.jar JAR file.
 
 Usage: java -jar ctzgenerator.jar [options] [output_file_name]
 options:

--- a/README
+++ b/README
@@ -23,8 +23,9 @@ some other compilers:
   but designators such as +03 or -07 are discarded, to be re-generated as
   needed.
 
-Make sure you have got a JDK (Java Development Kit) installed. If not you can
-install that with `sudo apt install default-jdk`.
+Make sure you have a JDK (Java Development Kit) installed. If not you can
+install that (on Linux) with `sudo apt install default-jdk`.
+
 Then simply type "make" at a command line prompt while in the top directory to
 build the ctzgenerator.jar JAR file.
 


### PR DESCRIPTION
It may be obvious, but make will fail with an error if no JDK is installed that allows to execute java files. So adding a note about that prerequisite seems a good idea.